### PR TITLE
tentative org-wide release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Project.toml
+
+jobs:
+  release:
+    runs-on: [ ubuntu-latest ]
+    if: contains(github.event.head_commit.message, 'release') ||
+        contains(github.event.head_commit.message, 'Release')
+    steps:
+      - name: comment on release commit
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.head_commit.id,
+              body: "@JuliaRegistrator register",
+            });


### PR DESCRIPTION
When a push event occurs (a merged PR) that modifies `Project.toml` and the commit message contains "Release" or "release", this action should automatically register the new version with JuliaRegistrator. Should be one less thing to have to do manually!