### PR TITLE
Organization-wide code of conduct and contributing files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement:
+`tangi.migot@gmail.com`.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -61,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement:
-`tangi.migot@gmail.com`.
+`tangi.migot@gmail.com` and `dominique.orban@gmail.com`.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributions
+
+We welcome contributions, which can come in many forms:
+\toc
+
+## Bug reports and discussions
+
+If you think you found a bug in any of our packages, feel free to open an issue at the specific GitHub repo.
+For our packages, it should be a link like `https://github.com/JuliaSmoothOptimizers/PACKAGE.jl`.
+For our tutorials, you can open an issue here or in <https://github.com/JuliaSmoothOptimizers/JSOTutorials.jl>.
+
+Focused suggestion and requests can also be opened as issues.
+Before opening a pull request, start an issue or a discussion on the topic, please.
+
+If you want to ask a question that is not suited for a bug report, feel free to start a discussion [here](https://github.com/JuliaSmoothOptimizers/Organization/discussions).
+This forum is for general discussion, so questions about any of our packages are welcome.
+
+## New tutorials
+
+Go to <https://github.com/JuliaSmoothOptimizers/JSOTutorials.jl>.
+
+## Style, colors, UI, frontend, etc
+
+[Check the issues for jso.dev](https://github.com/JuliaSmoothOptimizers/JuliaSmoothOptimizers.github.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc), and open a new one if necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
-# Contributions
+# Contributing to JuliaSmoothOptimizers
 
 We welcome contributions, which can come in many forms:
-\toc
 
 ## Bug reports and discussions
 
@@ -15,10 +14,6 @@ Before opening a pull request, start an issue or a discussion on the topic, plea
 If you want to ask a question that is not suited for a bug report, feel free to start a discussion [here](https://github.com/JuliaSmoothOptimizers/Organization/discussions).
 This forum is for general discussion, so questions about any of our packages are welcome.
 
-## New tutorials
+## JSO compliant solvers
 
-Go to <https://github.com/JuliaSmoothOptimizers/JSOTutorials.jl>.
-
-## Style, colors, UI, frontend, etc
-
-[Check the issues for jso.dev](https://github.com/JuliaSmoothOptimizers/JuliaSmoothOptimizers.github.io/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc), and open a new one if necessary.
+Please refer to <https://jso.dev/tutorials/creating-a-jso-compliant-solver/> for implementing new optimization solvers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Before opening a pull request, start an issue or a discussion on the topic, plea
 If you want to ask a question that is not suited for a bug report, feel free to start a discussion [here](https://github.com/JuliaSmoothOptimizers/Organization/discussions).
 This forum is for general discussion, so questions about any of our packages are welcome.
 
+Questions related to a specific package can also be asked in the Discussions section of the appropriate repository.
+
 ## New tutorials
 
 Go to <https://github.com/JuliaSmoothOptimizers/JSOTutorials.jl>.


### PR DESCRIPTION
closes #13

@dpo, @tmigot, @amontoison

This is very basic but we can start from here.

- I copy pasted the code of conduct from BestieTemplate: currently, @tmigot is the one responsible for enforcement (i just copied from SolverCore.jl) but we should definitely discuss this.
- I copy pasted the contributing file from the website but i think we should improve it because it is quite unclear (as someone who started contributing "recently" I can say this wasn't very helpful).

For the issue template and pr template, we can do it in a separate PR, I am not sure that @amontoison wants these but maybe I am wrong.