### PR TITLE
Add downgrade compatibility workflow

### DIFF
--- a/.github/workflows/downgrade-compat.yaml
+++ b/.github/workflows/downgrade-compat.yaml
@@ -1,0 +1,32 @@
+
+name: Downgrade-compat
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        downgrade_mode: ['deps', 'alldeps']
+        julia-version: ['lts', '1']
+        julia-arch: [x64]
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          mode: ${{ matrix.downgrade_mode }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: false
+          force_latest_compatible_version: false

--- a/.github/workflows/downgrade-compat.yaml
+++ b/.github/workflows/downgrade-compat.yaml
@@ -2,11 +2,7 @@
 name: Downgrade-compat
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
 
 jobs:
   test:


### PR DESCRIPTION
This workflow runs tests for different downgrade modes and Julia versions on push and pull request events.

Related discussion: https://github.com/orgs/JuliaSmoothOptimizers/discussions/73

cc @MaxenceGollier